### PR TITLE
Fix path to borrowers-force-messaging-defaults.pl

### DIFF
--- a/Koha/Plugin/MessagingPreferenceWizard.pm
+++ b/Koha/Plugin/MessagingPreferenceWizard.pm
@@ -96,7 +96,7 @@ sub tool {
 q|SELECT DISTINCT bo.borrowernumber, bo.categorycode FROM borrowers bo
 LEFT JOIN borrower_message_preferences mp USING (borrowernumber)
 WHERE 1|;
-        my $script_path = '../misc/maintenance/borrowers-force-messaging-defaults.pl';
+        my $script_path = '/usr/share/koha/bin/maintenance/borrowers-force-messaging-defaults.pl';
         my $command = "perl $script_path --doit";
         if ( $since ) {
             $command .= " --since $since";


### PR DESCRIPTION
MessagingPreferenceWizard.pm has this path to the standard script provided by Koha:

my $script_path = '../misc/maintenance/borrowers-force-messaging-defaults.pl';

We have not been able to make this work on a standard Debian install. On a dev install, the script is in "misc", but on a standard install it will be in "bin".

This patch proposes to change the script_path for the absolute path used on a Debian install. This will break things for dev installs, so a better approach would probably be to check if we are on a dev install, and set the path accordinlgy.